### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,16 +7,16 @@
 #######################################
 
 Temboo	KEYWORD1
-TembooMQTTEdgeDevice KEYWORD1
-TembooCoAPEdgeDevice KEYWORD1
+TembooMQTTEdgeDevice	KEYWORD1
+TembooCoAPEdgeDevice	KEYWORD1
 
 #######################################
 # Datatypes (KEYWORD2)
 #######################################
 
 TembooChoreo	KEYWORD2
-TembooCoAPChoreo KEYWORD2
-TembooMQTTChoreo KEYWORD2
+TembooCoAPChoreo	KEYWORD2
+TembooMQTTChoreo	KEYWORD2
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords